### PR TITLE
add sort(), limit() and skip()

### DIFF
--- a/lib/mongoskin/collection.js
+++ b/lib/mongoskin/collection.js
@@ -50,6 +50,10 @@ var SkinCollection = exports.SkinCollection = function(skinDb, collectionName) {
   });
 
   this.emitter = new events.EventEmitter();
+
+  this._sort = [];
+  this._limit = null;
+  this._skip = null;
 }
 
 var bindSkin = function(name, method) {
@@ -70,7 +74,8 @@ for (var name in Collection.prototype) {
   bindSkin(name, method);
 }
 
-SkinCollection.prototype._find = SkinCollection.prototype.find;
+//SkinCollection.prototype._find = SkinCollection.prototype.find;
+SkinCollection.prototype.__find = SkinCollection.prototype.find;
 
 SkinCollection.prototype.open = function(fn) {
   switch (this.state) {
@@ -167,4 +172,63 @@ SkinCollection.prototype.find = function() {
     return new SkinCursor(null, this, args);
   }
 };
+
+SkinCollection.prototype._find = function(){
+  var where = {};
+  var options = {};
+  var fn = null;
+
+  switch(arguments.length){
+    case 3:
+      where = arguments[0];
+      options = arguments[1];
+      fn = arguments[2];
+      break;
+    case 2:
+      where = arguments[0];
+      fn = arguments[1];
+      break;
+    case 1:
+      fn = arguments[0];
+      break;
+  }
+
+  if(this._sort.length > 0){
+    if(options.hasOwnProperty('sort')){
+      options['sort'] = options['sort'].concat(this._sort);
+    }
+    else{
+      options['sort'] = this._sort;
+    }
+  }
+
+  if(this._limit){
+    options['limit'] = this._limit;
+  }
+
+  if(this._skip){
+    options['skip'] = this._skip;
+  }
+
+  this.__find.apply(this, [where, options, fn])
+}
+
+SkinCollection.prototype.sort = function(obj) {
+  var sort = [];
+  for(key in obj){
+    sort.push([key, obj[key]])
+  }
+  this._sort = sort;
+  return this;
+}
+
+SkinCollection.prototype.limit = function(num) {
+  this._limit = num;
+  return this;
+}
+
+SkinCollection.prototype.skip = function(num) {
+  this._skip = num;
+  return this;
+}
 


### PR DESCRIPTION
Hello, gileen.

node-mongodb-native has awkward syntax to sort data.
So I add sort method with limit and skip.

But here is one cavity.
These methods should be called before any findXXX methods.
If it's possible, I would like to see more elegant sort() method implementation.

BTW,I love your way of implementation, especially bind() thing.
Thanks for your hard work.
