### PR TITLE
Passwords are allowed to contain colons.

### DIFF
--- a/lib/mongoskin/index.js
+++ b/lib/mongoskin/index.js
@@ -35,9 +35,10 @@ var parseUrl = function(serverUrl) {
   config.options['auto_reconnect'] = toBool(serverOptions['auto_reconnect']);
   config.options['poolSize'] = parseInt(serverOptions['poolSize'] || 1);
   if (uri && uri.auth) {
-    var auth = uri.auth.split(':');
-    config.username = auth[0];
-    config.password = auth[1];
+    var auth = uri.auth,
+        separator = auth.indexOf(':');
+    config.username = auth.substr(0, separator);
+    config.password = auth.substr(separator + 1);
   }
   return config;
 };


### PR DESCRIPTION
according to http://www.ietf.org/rfc/rfc2617.txt, passwords may contain colons, but using String#split() will fail if the password contains a colon.  This patch uses String#indexOf and String#substr, instead, so that passwords may contain colon(s).
