### PR TITLE
Add rootCollection option to SkinGridStore.exist

### DIFF
--- a/lib/mongoskin/gridfs.js
+++ b/lib/mongoskin/gridfs.js
@@ -30,9 +30,9 @@ SkinGridStore.prototype.unlink = SkinGridStore.prototype.remove = function(filen
   });
 }
 
-SkinGridStore.prototype.exist = function(filename, callback){
+SkinGridStore.prototype.exist = function(filename, rootCollection, callback){
   this.skinDb.open(function(err, db) {
-      GridStore.exist(db, filename, callback);
+      GridStore.exist(db, filename, rootCollection, callback);
   });
 }
 


### PR DESCRIPTION
I had a need to specify the rootCollection for SkinGridStore.exist.  It was a pretty simple fix since it is already an optional parameter on node-mongodb-native's GridStore.exist
