### PR TITLE
Check whether there's a callback to handle the open error

### DIFF
--- a/lib/mongoskin/collection.js
+++ b/lib/mongoskin/collection.js
@@ -69,7 +69,12 @@ var bindSkin = function(name, method) {
     var args = arguments.length > 0 ? __slice.call(arguments, 0) : [];
     this.open(function(err, collection) {
       if (err) {
-        args[args.length - 1](err);
+        var cb = args.pop();
+        if(cb) {
+          cb(err)
+        } else {
+          console.error("Error occured with no callback to handle it while calling SkinCollection." + name,  err);
+        }
       } else {
         method.apply(collection, args);
       }


### PR DESCRIPTION
On connect error I'm getting a slew of 'undefined is not a function' because no check is being done. Print an error message instead of there's no callback.
