### PR TITLE
Added properties object to the gridfs.open() callback

### DIFF
--- a/lib/mongoskin/gridfs.js
+++ b/lib/mongoskin/gridfs.js
@@ -19,7 +19,18 @@ SkinGridStore.prototype.open = function(id, filename, mode, options, callback){
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   this.skinDb.open(function(err, db) {
-      new GridStore(db, args[0], args[1], args[2], args[3]).open(callback);
+      var gs = new GridStore(db, args[0], args[1], args[2], args[3]);
+      var props = {
+        length: gs.length,
+        contentType: gs.contentType,
+        uploadDate: gs.uploadDate,
+        metadata: gs.metadata,
+        chunkSize: gs.chunkSize
+      };
+      
+      gs.open(function(error, reply) {
+        callback(error, reply, props);
+      });
   });
 }
 


### PR DESCRIPTION
Way things stand, there's no way to retrieve properties like contentType and metadata. Added it as an additional parameter to gridfs.open() callback.
