### PR TITLE
Allow authentication database option.

### DIFF
--- a/lib/mongoskin/db.js
+++ b/lib/mongoskin/db.js
@@ -33,7 +33,7 @@ var STATE_OPEN = constant.STATE_OPEN;
  * @constructor
  * @api public
  */
-var SkinDb = exports.SkinDb = function (dbconn, username, password) {
+var SkinDb = exports.SkinDb = function (dbconn, username, password, options) {
   utils.SkinObject.call(this);
   this.emitter.setMaxListeners(100);
 
@@ -41,6 +41,7 @@ var SkinDb = exports.SkinDb = function (dbconn, username, password) {
   this.db = null;
   this.username = username;
   this.password = password;
+  this.options = options;
   this.admin = new SkinAdmin(this);
   this._collections = {};
   this.bson_serializer = dbconn.bson_serializer;
@@ -102,7 +103,11 @@ SkinDb.prototype.open = function (callback) {
       this._dbconn.open(function (err, db) {
         if (db && this.username) {
           // do authenticate
-          db.authenticate(this.username, this.password, function (err) {
+          var authOptions = {};
+          if (this.options.authdb !== undefined) {
+            authOptions.authdb = this.options.authdb;
+          }
+          db.authenticate(this.username, this.password, authOptions, function (err) {
             onDbOpen(err, db);
           });
         } else {

--- a/lib/mongoskin/server.js
+++ b/lib/mongoskin/server.js
@@ -47,7 +47,7 @@ SkinServer.prototype.db = function (name, options) {
       options.native_parser = !! mongodb.BSONNative;
     }
     var db = new Db(name, this.server, options);
-    skinDb = new SkinDb(db, username, password);
+    skinDb = new SkinDb(db, username, password, options);
     this._cache_[key] = skinDb;
   }
   return skinDb;


### PR DESCRIPTION
This is a pretty crude way to allow authentication to a different database than the one we are connecting to.
Mainly used to allow authenticate to the admin db before using any other.

```
require('mongoskin').db('root:root@some.place/voodoo-geoah', {
  safe: true,
  authdb: 'admin'
}).collection('settings').find().toArray(function(err, items) {
  if (err) {
    return console.error(err);
  } else {
    return console.dir(items);
  }
});
```

I've been using mongoskin for couple of hours so please excuse me if I have missed something very obvious.
