### PR TITLE
Fixed typo in readme for toObjectID method name

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -138,7 +138,7 @@ var myCollection = db.collection('myCollection', {strict: true});
 
 ### module.db(...)
 alias `MongoClient.connect(...)`
-### module.helper.toObjectId(hexStr)
+### module.helper.toObjectID(hexStr)
 convert `String` to `ObjectID` instance.
 ### db.bind(name, options)
 alias `db[name] = db.collection(name, options)`


### PR DESCRIPTION
The readme has toObjectId instead of toObjectID.
