### PR TITLE
Relax mongodb version constraint for v2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "node": ">= 0.4.0"
   },
   "peerDependencies": {
-    "mongodb": "~2.0"
+    "mongodb": "^2.0"
   },
   "devDependencies": {
     "istanbul": "0.3.17",
@@ -29,7 +29,7 @@
     "coveralls": "~2.10.0",
     "mocha-lcov-reporter": "0.0.1",
     "travis-cov": "~0.2.5",
-    "mongodb": "~2.0",
+    "mongodb": "^2.0",
     "should": "~3.1.2"
   },
   "scripts": {

--- a/test/admin.js
+++ b/test/admin.js
@@ -12,7 +12,9 @@ exports.testWithDb = function(db) {
         });
 
         it('should authenticate using the newly added user', function(done) {
+          adminDb.logout(function(err, result) {
             adminDb.authenticate('admin3', 'admin3', done);
+          });
         })
 
         it('should remove user just added', function(done) {


### PR DESCRIPTION
Second attempt of https://github.com/kissjs/node-mongoskin/pull/188, fixed test.
Relate to https://github.com/kissjs/node-mongoskin/issues/163.